### PR TITLE
Auto select port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 #### Latest Changes ####
 * 2.0.0
-    * Added: warning if JAVA6_HOME env variable is not set
     * added "queries file" support analogical to "headers file". 
     * added ability to put headers in separate file. If both "headers file" and "headers" are present in config for request "headers" will have priority.
     * ability to put request in separate file, by putting filepath to requests array (instead of full object)
+    * failure to start server will now throw exception instead of returning null
+    * If `port` is not specified in the config file ports in inclusive range 8099-8104 will be tried 
 * 1.4.2 
     * When returning code 404 also log what path was requested. 
 * 1.4.1

--- a/mockserver/build.gradle
+++ b/mockserver/build.gradle
@@ -34,10 +34,10 @@ dependencies {
     // adds the @Generated annotation for auto value
     provided 'javax.annotation:jsr250-api:1.0'
 
-    testCompile group: 'junit', name: 'junit', version: '4.10'
-    testCompile 'org.mockito:mockito-core:1.9.5'
-    testCompile 'org.assertj:assertj-core:1.7.1'
-    testCompile 'org.apache.commons:commons-io:1.3.2'
+    testImplementation group: 'junit', name: 'junit', version: '4.10'
+    testImplementation 'org.mockito:mockito-core:1.9.5'
+    testImplementation 'org.assertj:assertj-core:1.7.1'
+    testImplementation 'org.apache.commons:commons-io:1.3.2'
 }
 
 apply from: 'maven-push.gradle'

--- a/mockserver/src/main/java/com/byoutline/mockserver/ConfigReader.java
+++ b/mockserver/src/main/java/com/byoutline/mockserver/ConfigReader.java
@@ -6,7 +6,7 @@ import java.io.InputStream;
 /**
  * Wraps platform specific bits.
  *
- * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com>
+ * @author Sebastian Kacprzak |sebastian.kacprzak at byoutline.com|
  * @see <a
  * href="https://github.com/byoutline/AndroidStubServer">AndroidMockServer
  * implementation</a>

--- a/mockserver/src/main/java/com/byoutline/mockserver/DefaultValues.java
+++ b/mockserver/src/main/java/com/byoutline/mockserver/DefaultValues.java
@@ -5,6 +5,7 @@ import com.byoutline.mockserver.internal.MatchingMethod;
 
 public final class DefaultValues {
     public static final int MOCK_SERVER_PORT = 8099;
+    public static final int MOCK_SERVER_MAX_PORT = 8104;
     public static final int RESPONSE_CODE = 200;
     public static final String RESPONSE = "OK";
     public static final MatchingMethod QUERY_MATCHING_METHOD = MatchingMethod.CONTAINS;

--- a/mockserver/src/main/java/com/byoutline/mockserver/HttpMockServer.java
+++ b/mockserver/src/main/java/com/byoutline/mockserver/HttpMockServer.java
@@ -1,9 +1,11 @@
 package com.byoutline.mockserver;
 
+import com.byoutline.mockserver.internal.AutoPortConnect;
 import com.byoutline.mockserver.internal.ConfigParser;
 import com.byoutline.mockserver.internal.MockNetworkLag;
 import com.byoutline.mockserver.internal.ParsedConfig;
 import com.byoutline.mockserver.internal.ResponseHandler;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.simpleframework.http.Request;
@@ -12,37 +14,34 @@ import org.simpleframework.http.core.Container;
 import org.simpleframework.http.core.ContainerServer;
 import org.simpleframework.transport.Server;
 import org.simpleframework.transport.connect.Connection;
-import org.simpleframework.transport.connect.SocketConnection;
+
+import java.io.IOException;
 
 import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Local mock HTTP server.
  */
 public class HttpMockServer implements Container {
 
-    private final static Logger LOGGER = Logger.getLogger(HttpMockServer.class.getName());
-
     public static boolean DEBUG = true;
     private final Connection conn;
     private final ResponseHandler responseHandler;
 
+    // Reference is kept only to prevent server from being garbage collected
     private static HttpMockServer sMockServer;
 
-    public HttpMockServer(@Nonnull JSONObject jsonObject, @Nonnull ConfigReader configReader, @Nonnull NetworkType simulatedNetworkType)
-            throws IOException, JSONException {
+    public HttpMockServer(
+            @Nonnull JSONObject jsonObject,
+            @Nonnull ConfigReader configReader,
+            @Nonnull NetworkType simulatedNetworkType
+    ) throws IOException, JSONException {
         ParsedConfig config = new ConfigParser(configReader).parseConfig(jsonObject);
         MockNetworkLag networkLag = new MockNetworkLag(simulatedNetworkType);
         this.responseHandler = new ResponseHandler(config.responses, networkLag, configReader);
         Server server = new ContainerServer(this);
-        conn = new SocketConnection(server);
-        final SocketAddress sa = new InetSocketAddress(config.port);
-        conn.connect(sa);
+
+        conn = new AutoPortConnect().connectToPortFromRange(server, config.port, config.maxPort);
     }
 
     /**
@@ -51,18 +50,16 @@ public class HttpMockServer implements Container {
      * @param configReader         wrapper for platform specific bits
      * @param simulatedNetworkType delay time before response is sent.
      */
-    public static HttpMockServer startMockApiServer(@Nonnull ConfigReader configReader,
-                                                    @Nonnull NetworkType simulatedNetworkType) {
-        try {
-            JSONObject jsonObj = ConfigParser.getMainConfigJson(configReader);
-            sMockServer = new HttpMockServer(jsonObj, configReader, simulatedNetworkType);
-            return sMockServer;
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, "MockServer error:", e);
-        } catch (JSONException e) {
-            LOGGER.log(Level.SEVERE, "MockServer error:", e);
-        }
-        return null;
+    public static HttpMockServer startMockApiServer(
+            @Nonnull ConfigReader configReader,
+            @Nonnull NetworkType simulatedNetworkType
+    ) throws IOException {
+        JSONObject jsonObj = ConfigParser.getMainConfigJson(configReader);
+        HttpMockServer mockServer;
+        mockServer = new HttpMockServer(jsonObj, configReader, simulatedNetworkType);
+
+        sMockServer = mockServer;
+        return mockServer;
     }
 
     public void reset() {
@@ -71,6 +68,7 @@ public class HttpMockServer implements Container {
 
     public void shutdown() throws Exception {
         conn.close();
+        sMockServer = null;
         this.reset();
     }
 

--- a/mockserver/src/main/java/com/byoutline/mockserver/NetworkType.java
+++ b/mockserver/src/main/java/com/byoutline/mockserver/NetworkType.java
@@ -1,7 +1,9 @@
 package com.byoutline.mockserver;
 
 /**
- * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com> on 14.04.14.
+ * Contains expected delays for common network types.
+ *
+ * @author Sebastian Kacprzak |sebastian.kacprzak at byoutline.com| on 14.04.14.
  */
 public enum NetworkType {
     /**

--- a/mockserver/src/main/java/com/byoutline/mockserver/internal/AutoPortConnect.java
+++ b/mockserver/src/main/java/com/byoutline/mockserver/internal/AutoPortConnect.java
@@ -1,0 +1,57 @@
+package com.byoutline.mockserver.internal;
+
+
+import org.simpleframework.transport.Server;
+import org.simpleframework.transport.connect.Connection;
+import org.simpleframework.transport.connect.SocketConnection;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+public class AutoPortConnect {
+    private final Connector connector;
+
+    public AutoPortConnect() {
+        this(new HttpServerConnector());
+    }
+
+    public AutoPortConnect(Connector connector) {
+        this.connector = connector;
+    }
+
+    /**
+     * Attempts to connect to all ports from given range. If all attempts fails exception will be thrown.
+     */
+    public Connection connectToPortFromRange(Server server, int minPort, int maxPort) throws IOException {
+        if (minPort > maxPort || minPort < 0 || maxPort > 65535) {
+            throw new IllegalArgumentException(String.format("Invalid port range - min: %d, max: %d", minPort, maxPort));
+        }
+
+        for (int port = minPort; port<=maxPort; port++) {
+            try {
+                return connector.connectToPort(port, server);
+            } catch (IOException e) {
+                if (port >= maxPort) {
+                    throw e;
+                }
+            }
+        }
+        throw new AssertionError(String.format("Failed to connect to any port from range %d %d", minPort, maxPort));
+    }
+}
+
+interface Connector {
+    Connection connectToPort(int port, Server server) throws IOException;
+}
+
+class HttpServerConnector implements Connector {
+
+    @Override
+    public Connection connectToPort(int port, Server server) throws IOException {
+        SocketConnection conn = new SocketConnection(server);
+        SocketAddress sa = new InetSocketAddress(port);
+        conn.connect(sa);
+        return conn;
+    }
+}

--- a/mockserver/src/main/java/com/byoutline/mockserver/internal/ConfigKeys.java
+++ b/mockserver/src/main/java/com/byoutline/mockserver/internal/ConfigKeys.java
@@ -3,7 +3,7 @@ package com.byoutline.mockserver.internal;
 /**
  * List of JSON keys that can be used in config file.
  *
- * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com> on 14.04.14.
+ * @author Sebastian Kacprzak |sebastian.kacprzak at byoutline.com| on 14.04.14.
  */
 public class ConfigKeys {
     public static final String PORT = "port";

--- a/mockserver/src/main/java/com/byoutline/mockserver/internal/ConfigParser.java
+++ b/mockserver/src/main/java/com/byoutline/mockserver/internal/ConfigParser.java
@@ -3,21 +3,33 @@ package com.byoutline.mockserver.internal;
 import com.byoutline.mockserver.ConfigReader;
 import com.byoutline.mockserver.DefaultValues;
 import com.byoutline.mockserver.HttpMockServer;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.io.*;
-import java.util.*;
 
 /**
  * Parses {@link HttpMockServer} config file and
  * responses from assets.
  *
  * @author Sylwester Madej
- * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com> on 14.04.14.
+ * @author Sebastian Kacprzak |sebastian.kacprzak at byoutline.com| on 14.04.14.
  */
 public class ConfigParser {
 
@@ -51,14 +63,19 @@ public class ConfigParser {
     }
 
     public ParsedConfig parseConfig(@Nonnull JSONObject configJson) throws JSONException, IOException {
-        int port = configJson.optInt(ConfigKeys.PORT, DefaultValues.MOCK_SERVER_PORT);
+        int port = configJson.optInt(ConfigKeys.PORT, -1);
+        int maxPort = port;
+        if (port == -1) {
+            port = DefaultValues.MOCK_SERVER_PORT;
+            maxPort = DefaultValues.MOCK_SERVER_MAX_PORT;
+        }
 
         JSONArray jsonArrayOfRequests = configJson.has(ConfigKeys.REQUESTS)
                 ? configJson.getJSONArray(ConfigKeys.REQUESTS)
                 : new JSONArray();
 
         parseRequests(jsonArrayOfRequests);
-        return new ParsedConfig(port, responses);
+        return new ParsedConfig(port, maxPort, responses);
     }
 
     private void parseRequests(JSONArray jsonArrayOfRequests) throws IOException {

--- a/mockserver/src/main/java/com/byoutline/mockserver/internal/MatchingMethod.java
+++ b/mockserver/src/main/java/com/byoutline/mockserver/internal/MatchingMethod.java
@@ -1,8 +1,5 @@
 package com.byoutline.mockserver.internal;
 
-/**
- * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com>
- */
 public enum MatchingMethod {
     EXACT("EXACT"), CONTAINS("CONTAINS"), NOT_CONTAINS("NOT_CONTAINS"), ANY("ANY");
     public final String configValue;

--- a/mockserver/src/main/java/com/byoutline/mockserver/internal/MockNetworkLag.java
+++ b/mockserver/src/main/java/com/byoutline/mockserver/internal/MockNetworkLag.java
@@ -6,9 +6,6 @@ import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com>
- */
 public final class MockNetworkLag {
     private final static Logger LOGGER = Logger.getLogger(MockNetworkLag.class.getName());
     private final Random random = new Random();

--- a/mockserver/src/main/java/com/byoutline/mockserver/internal/ParsedConfig.java
+++ b/mockserver/src/main/java/com/byoutline/mockserver/internal/ParsedConfig.java
@@ -3,16 +3,15 @@ package com.byoutline.mockserver.internal;
 import java.util.List;
 import java.util.Map;
 
-/**
- * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com>
- */
 public final class ParsedConfig {
 
     public final int port;
+    public final int maxPort;
     public final List<Map.Entry<RequestParams, ResponseParams>> responses;
 
-    public ParsedConfig(int port, List<Map.Entry<RequestParams, ResponseParams>> responses) {
+    public ParsedConfig(int port, int maxPort, List<Map.Entry<RequestParams, ResponseParams>> responses) {
         this.port = port;
+        this.maxPort = maxPort;
         this.responses = responses;
     }
 }

--- a/mockserver/src/main/java/com/byoutline/mockserver/internal/RequestParams.java
+++ b/mockserver/src/main/java/com/byoutline/mockserver/internal/RequestParams.java
@@ -8,9 +8,6 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Map;
 
-/**
- * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com> on 15.04.14.
- */
 @AutoValue
 public abstract class RequestParams {
 

--- a/mockserver/src/main/java/com/byoutline/mockserver/internal/ResponseHandler.java
+++ b/mockserver/src/main/java/com/byoutline/mockserver/internal/ResponseHandler.java
@@ -18,8 +18,8 @@ import java.util.logging.Logger;
 /**
  * Takes care of replying to requests.
  *
- * @author Sylwester Madej <sylwester.madej at byoutline.com>
- * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com> on 14.04.14.
+ * @author Sylwester Madej |sylwester.madej at byoutline.com|
+ * @author Sebastian Kacprzak |sebastian.kacprzak at byoutline.com| on 14.04.14.
  */
 public class ResponseHandler {
 

--- a/mockserver/src/test/groovy/com/byoutline/mockserver/internal/AutoPortConnectSpec.groovy
+++ b/mockserver/src/test/groovy/com/byoutline/mockserver/internal/AutoPortConnectSpec.groovy
@@ -1,0 +1,92 @@
+package com.byoutline.mockserver.internal
+
+import com.byoutline.mockserver.DefaultValues
+import org.simpleframework.transport.Server
+import org.simpleframework.transport.connect.Connection
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class AutoPortConnectSpec extends Specification {
+    Server server = Mock()
+    def connector = new MockConnector()
+    def instance = new AutoPortConnect(connector)
+
+    @Unroll
+    def "should attempt to connect to ports: #expPorts for minPort: #minPort, maxPort: #maxPort given unavailable ports: #errorPorts"() {
+        given: 'Mock connector'
+        connector.errorPorts = errorPorts
+
+        when: 'ports are passed to method'
+        instance.connectToPortFromRange(server, minPort, maxPort)
+
+        then: 'expected ports were attempted'
+        connector.attemptedPorts == expPorts
+
+        where:
+        minPort | maxPort | errorPorts           | expPorts
+        1       | 1       | []                   | [1]
+        2       | 4       | [2, 3]               | [2, 3, 4]
+        10      | 15      | []                   | [10]
+        10      | 15      | [10, 11, 12, 13, 14] | [10, 11, 12, 13, 14, 15]
+    }
+
+    @Unroll
+    def "should throw exception if all ports were busy #ports"() {
+        given:
+        def minPort = ports[0]
+        def maxPort = ports[1]
+        connector.errorPorts = minPort..maxPort + 1
+
+        when:
+        instance.connectToPortFromRange(server, minPort, maxPort)
+
+        then:
+        thrown IOException
+
+        where:
+        ports << [[DefaultValues.MOCK_SERVER_PORT, DefaultValues.MOCK_SERVER_PORT], [1, 5]]
+    }
+
+    @Unroll
+    def "should throw exception if invalid ports were passed: #ports"() {
+        given:
+        def minPort = ports[0]
+        def maxPort = ports[1]
+        connector.errorPorts = minPort..maxPort + 1
+
+        when:
+        instance.connectToPortFromRange(server, minPort, maxPort)
+
+        then:
+        thrown IllegalArgumentException
+
+        where:
+        ports << [[-1, 1], [70000, 70000], [2, 1]]
+    }
+
+    def "should try only single port if port specified and throw exception if it fails"() {
+        given:
+        connector.errorPorts = [1]
+
+        when:
+        instance.connectToPortFromRange(server, 1, 1)
+
+        then:
+        connector.attemptedPorts == [1]
+        thrown IOException
+    }
+}
+
+class MockConnector implements Connector {
+    List<Integer> attemptedPorts = []
+    List<Integer> errorPorts = []
+
+    @Override
+    Connection connectToPort(int port, Server server) throws IOException {
+        attemptedPorts.add(port)
+        if (errorPorts.contains(port)) {
+            throw new IOException("Port busy")
+        }
+        return null
+    }
+}

--- a/mockserver/src/test/groovy/com/byoutline/mockserver/internal/ConfigParserRequestParsingSpec.groovy
+++ b/mockserver/src/test/groovy/com/byoutline/mockserver/internal/ConfigParserRequestParsingSpec.groovy
@@ -156,6 +156,7 @@ class ConfigParserRequestParsingSpec extends Specification {
         then:
         result.responses.isEmpty()
         result.port == DefaultValues.MOCK_SERVER_PORT
+        result.maxPort == DefaultValues.MOCK_SERVER_MAX_PORT
     }
 
     def "should set port from config"() {
@@ -167,6 +168,7 @@ class ConfigParserRequestParsingSpec extends Specification {
         def result = instance.parseConfig(json)
         then:
         result.port == 1234
+        result.maxPort == 1234
     }
 
     @Unroll

--- a/sample/src/main/java/com/byoutline/mockserver/sample/ConfigServer.java
+++ b/sample/src/main/java/com/byoutline/mockserver/sample/ConfigServer.java
@@ -12,17 +12,20 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
 
 /**
  * Sample that reads config from given path and starts a local server.
  * Other then being a sample this can be used for debugging config files.
+ * <p>
+ * This server will run until interrupted.
  *
  * @author michalp on 25.04.16.
  */
 public class ConfigServer {
-    public static void main(String... args) {
+    public static void main(String... args) throws IOException {
         Options options = new Options();
         options.addOption("n", true, "network type(GPRS,EDGE,UMTS,VPN,NO_DELAY)")
                 .addOption("h", false, "help message");
@@ -47,7 +50,7 @@ public class ConfigServer {
         }
     }
 
-    private static void searchMockPathAndRunServer(CommandLine cmd, NetworkType networkType) {
+    private static void searchMockPathAndRunServer(CommandLine cmd, NetworkType networkType) throws IOException {
         List targetList = cmd.getArgList();
         if (targetList.isEmpty()) {
             System.out.println("Path not detected,enter the path to mock resources.");
@@ -88,7 +91,7 @@ public class ConfigServer {
         formatter.printWrapped(out, width, "");
     }
 
-    private static boolean runServerWithPath(String path, NetworkType networkType) {
+    private static boolean runServerWithPath(String path, NetworkType networkType) throws IOException {
         final HttpMockServer httpMockServer = HttpMockServer.startMockApiServer(new SampleReader(path), networkType);
         try {
             synchronized (httpMockServer) {

--- a/sample/src/main/java/com/byoutline/mockserver/sample/Sample.java
+++ b/sample/src/main/java/com/byoutline/mockserver/sample/Sample.java
@@ -19,7 +19,7 @@ public class Sample {
 
     private static HttpMockServer httpMockServer;
 
-    public static void main(String... args) {
+    public static void main(String... args) throws IOException, InterruptedException {
         httpMockServer = HttpMockServer.startMockApiServer(new SampleReader(), NetworkType.GPRS);
         doSomethingWithUsingHttpMockServer();
         shutDownSerwer();


### PR DESCRIPTION
By default MockServer will try to open range of ports. Failure will throw exception. 

This is supposed to help with case where 2 application have same port in config. Previously if the return value was not checked it may not be apparent what was wrong.

* This case will trigger if no port is defined
* If port is defined only this port will be attempted (same as old behaviour)
* Previously only single port was attempted

* This commits additionally clears JavaDoc warnings

This was tested on Linux only, but it probably should also for on other platforms.
Example output of launching 6 servers at once (with temporary debug prints):
Sample jar build via `/gradlew clean sampleCompleteJar`
launched by `$ java -cp sample/build/libs/sample.jar com.byoutline.mockserver.sample.ConfigServer sample/src/main/resources/`
with config without `port` defined

```
#1
connected to port: 8099


#2
failed to connect to port: 8099
connected to port: 8100


#3
failed to connect to port: 8099
failed to connect to port: 8100
connected to port: 8101


#4
failed to connect to port: 8099
failed to connect to port: 8100
failed to connect to port: 8101
connected to port: 8102


#5
failed to connect to port: 8099
failed to connect to port: 8100
failed to connect to port: 8101
failed to connect to port: 8102
connected to port: 8103


#6
failed to connect to port: 8099
failed to connect to port: 8100
failed to connect to port: 8101
failed to connect to port: 8102
failed to connect to port: 8103
connected to port: 8104


#7
failed to connect to port: 8099
failed to connect to port: 8100
failed to connect to port: 8101
failed to connect to port: 8102
failed to connect to port: 8103
failed to connect to port: 8104
Exception in thread "main" java.net.BindException: Adres jest już w użyciu
        at sun.nio.ch.Net.bind0(Native Method)
        at sun.nio.ch.Net.bind(Net.java:433)
        at sun.nio.ch.Net.bind(Net.java:425)
        at sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:223)
        at sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:74)
        at org.simpleframework.transport.connect.SocketAcceptor.bind(SocketAcceptor.java:183)
        at org.simpleframework.transport.connect.SocketAcceptor.<init>(SocketAcceptor.java:100)
        at org.simpleframework.transport.connect.SocketListener.<init>(SocketListener.java:81)
        at org.simpleframework.transport.connect.SocketListenerManager.listen(SocketListenerManager.java:98)
        at org.simpleframework.transport.connect.SocketListenerManager.listen(SocketListenerManager.java:81)
        at org.simpleframework.transport.connect.SocketConnection.connect(SocketConnection.java:106)
        at com.byoutline.mockserver.internal.HttpServerConnector.connectToPort(AutoPortConnect.java:56)
        at com.byoutline.mockserver.internal.AutoPortConnect.connectToPortFromRange(AutoPortConnect.java:34)
        at com.byoutline.mockserver.HttpMockServer.<init>(HttpMockServer.java:44)
        at com.byoutline.mockserver.HttpMockServer.startMockApiServer(HttpMockServer.java:59)
        at com.byoutline.mockserver.sample.ConfigServer.runServerWithPath(ConfigServer.java:95)
        at com.byoutline.mockserver.sample.ConfigServer.searchMockPathAndRunServer(ConfigServer.java:67)
        at com.byoutline.mockserver.sample.ConfigServer.main(ConfigServer.java:47)
```